### PR TITLE
Ensuring that events are not emitted more then it should

### DIFF
--- a/src/event-emitter.lisp
+++ b/src/event-emitter.lisp
@@ -87,7 +87,7 @@
                (apply fn args)
                (when (listener-once listener)
                  (remove-listener object event fn))))
-         listeners)
+         (copy-seq listeners))
     T))
 
 (defun listener-count (object event)


### PR DESCRIPTION
I noticed that some of my :once handlers where emitted several times.
That is because event-emitter is maping over a vector, and at the same time deleting items from that same vector.