### PR TITLE
Fix portability edge-case

### DIFF
--- a/src/event-emitter.lisp
+++ b/src/event-emitter.lisp
@@ -21,22 +21,22 @@
 (defstruct (listener (:constructor make-listener (function &key once)))
   function once)
 
-(defun %add-listener (object event listener)
-  (let* ((silo (silo object))
-         (listeners (gethash event silo)))
-    (if listeners
-        (progn (vector-push-extend listener listeners)
-               listeners)
-        (setf (gethash event silo)
-              (make-array 1 :element-type 'listener
-                            :adjustable t :fill-pointer 1
-                            :initial-contents (list listener))))))
+(defun %add-listener (silo event listener &aux (listeners (gethash event silo)))
+  (flet ((reinit-silo (&aux (length (1+ (length listeners))))
+           (setf (gethash event silo)
+                 (make-array length :element-type 'listener :adjustable t
+                             :fill-pointer length :initial-contents
+                             (cons listener (coerce listeners 'list))))))
+    (multiple-value-bind (vector failed)
+        (with-simple-restart (continue "Allocate a new non-simple array")
+          (if listeners (vector-push-extend listener listeners) (reinit-silo)))
+      (if (not failed) vector (reinit-silo)))))
 
 (defun add-listener (object event listener)
-  (%add-listener object event (make-listener listener)))
+  (%add-listener (silo object) event (make-listener listener)))
 
 (defun on (event object listener)
-  (%add-listener object event (make-listener listener)))
+  (%add-listener (silo object) event (make-listener listener)))
 
 (defun once (event object listener)
   (%add-listener object event (make-listener listener :once t)))


### PR DESCRIPTION
As reported in #4, certain compilers will not return an adjustable vector from `#'delete`, due to the ANSI specification only requiring that the array element type remain unchanged, while permitting the return value to be a simple vector; this can cause a situation wherein the object's event silo is not extensible, and an error will be signaled upon the next attempt to add a listener.

This commit provides a CONTINUE restart ensuring that the silo is adjustable, along with a minor change to the portions of code that are inlined; the change of inlining should not be noticeable.