### PR TITLE
EMIT function now set up a REMOVE-LISTENER restart

### DIFF
--- a/src/event-emitter.lisp
+++ b/src/event-emitter.lisp
@@ -80,17 +80,26 @@
 
 (defun emit (event object &rest args)
   (let* ((listeners (listeners object event))
-		 (max-size (length listeners)))
+         (max-size (length listeners)))
     (when (zerop max-size)
       (return-from emit nil))
-	(do ((indx 0 (1+ indx)))
-		((>= indx max-size))
-	  (apply (listener-function (elt listeners indx)) args)
-	  (when (listener-once (elt listeners indx))
-		(remove-listener object event (listener-function (elt listeners indx))
-						 :start indx)
-		(decf max-size)
-		(decf indx)))
+    (do ((indx 0 (1+ indx)))
+        ((>= indx max-size))
+      
+      (flet ((remove-current-listener ()
+               (remove-listener object event (listener-function (elt listeners indx))
+                                :start indx)
+               (decf max-size)
+               (decf indx)))
+        (declare (dynamic-extent #'remove-current-listener))
+        
+        (restart-case
+            (progn (apply (listener-function (elt listeners indx)) args)
+                   (when (listener-once (elt listeners indx))
+                     (remove-current-listener)))
+          (remove-listener ()
+            :report "Remove listener and continue."
+            (remove-current-listener)))))
     t))
 
 (defun listener-count (object event)


### PR DESCRIPTION
This restart could be used to remove current listener which might be useful if during the call to the listener some unrecoverable error was encountered or if the listener discovers it obsolescence.