### PR TITLE
remove `(in-package :cl-user)`

### DIFF
--- a/src/event-emitter.lisp
+++ b/src/event-emitter.lisp
@@ -1,4 +1,3 @@
-(in-package :cl-user)
 (defpackage event-emitter
   (:use :cl)
   (:export :event-emitter


### PR DESCRIPTION
Removed `(in-package :cl-user)`.
This has enabled us to save 22 bytes in the size of this library.
It also reduces the cost at compile time.