### PR TITLE
remove inline declarations and refactoring

### DIFF
--- a/event-emitter-benchmark.asd
+++ b/event-emitter-benchmark.asd
@@ -1,0 +1,6 @@
+(defsystem "event-emitter-benchmark"
+  :depends-on ("event-emitter")
+  :serial t
+  :components ((:file "t/benchmark"))
+  :perform (test-op :after (o c)
+                    (uiop:symbol-call :event-emitter-benchmark :main)))

--- a/src/event-emitter.lisp
+++ b/src/event-emitter.lisp
@@ -13,17 +13,13 @@
 (in-package :event-emitter)
 
 (defclass event-emitter ()
-  ((silo :initform (make-hash-table :test 'eq))))
+  ((silo :initform (make-hash-table :test 'eq) :accessor silo)))
 
 (defstruct event-emitter*
   (silo (make-hash-table :test 'eq)))
 
 (defstruct (listener (:constructor make-listener (function &key once)))
   function once)
-
-(declaim (inline silo))
-(defun silo (object)
-  (slot-value object 'silo))
 
 (defun %add-listener (object event listener)
   (let* ((silo (silo object))
@@ -36,15 +32,12 @@
                             :adjustable t :fill-pointer 1
                             :initial-contents (list listener))))))
 
-(declaim (inline add-listener))
 (defun add-listener (object event listener)
   (%add-listener object event (make-listener listener)))
 
-(declaim (inline on))
 (defun on (event object listener)
   (%add-listener object event (make-listener listener)))
 
-(declaim (inline once))
 (defun once (event object listener)
   (%add-listener object event (make-listener listener :once t)))
 
@@ -65,7 +58,7 @@
 (defun remove-all-listeners (object &optional event)
   (if event
       (remhash event (silo object))
-      (setf (slot-value object 'silo)
+      (setf (silo object)
             (make-hash-table :test 'eq)))
   (values))
 

--- a/t/benchmark.lisp
+++ b/t/benchmark.lisp
@@ -1,0 +1,21 @@
+(defpackage :event-emitter-benchmark
+  (:use :cl
+        :event-emitter))
+(in-package :event-emitter-benchmark)
+
+(defclass foo (event-emitter) ())
+
+(defvar *foo*)
+
+(defvar *counter* 0)
+
+(defun unit ()
+  (setf *foo* (make-instance 'foo))
+  (on :say-hi *foo* (lambda () (incf *counter*)))
+  (emit :say-hi *foo*))
+
+(defun benchmark ()
+  (loop :repeat 10000000 :do (unit)))
+
+(defun main ()
+  (time (benchmark)))


### PR DESCRIPTION
I removed the inline declaration and refactored the code.
I couldn't think of any particular advantages to this inline declaration, but as a disadvantage of inline declarations, debugging information is lost and the code becomes less readable.
I also think it is better to optimize the internal implementation rather than inlining the exported functions.